### PR TITLE
[Feat] #10

### DIFF
--- a/src/main/java/yeonjeans/saera/AppConfig.java
+++ b/src/main/java/yeonjeans/saera/AppConfig.java
@@ -3,30 +3,9 @@ package yeonjeans.saera;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
-import yeonjeans.saera.Service.StatementService;
-import yeonjeans.saera.Service.StatementServiceImpl;
-import yeonjeans.saera.Service.MemberService;
-import yeonjeans.saera.Service.MemberServiceImpl;
-import yeonjeans.saera.domain.statement.StatementRepository;
-import yeonjeans.saera.domain.member.MemberRepository;
-import yeonjeans.saera.domain.statement.TagRepository;
 
 @Configuration
 public class AppConfig {
-
-    private StatementRepository statementRepository;
-    private MemberRepository userRepository;
-    private TagRepository tagRepository;
-
-    @Bean
-    public StatementService StatementService() {
-        return new StatementServiceImpl(statementRepository, tagRepository, webClient());
-    }
-
-    @Bean
-    public MemberService UserService(){
-        return new MemberServiceImpl(userRepository);
-    }
 
     @Bean
     public WebClient webClient() {

--- a/src/main/java/yeonjeans/saera/Service/PracticedServiceImpl.java
+++ b/src/main/java/yeonjeans/saera/Service/PracticedServiceImpl.java
@@ -51,7 +51,7 @@ public class PracticedServiceImpl {
         Member member = memberRepository.findById(1L).orElseThrow(()->new CustomException(MEMBER_NOT_FOUND));
         Statement statement = statementRepository.findById(dto.getId()).orElseThrow(()->new CustomException(STATEMENT_NOT_FOUND));
 
-        Optional<Practiced> oldPracticed = practicedRepository.findById(dto.getId());
+        Optional<Practiced> oldPracticed = practicedRepository.findByStatementAndMember(statement, member);
         if(oldPracticed.isPresent()){
             String oldPath = oldPracticed.get().getRecord().getPath();
             practicedRepository.delete(oldPracticed.get());

--- a/src/main/java/yeonjeans/saera/Service/StatementService.java
+++ b/src/main/java/yeonjeans/saera/Service/StatementService.java
@@ -2,16 +2,15 @@ package yeonjeans.saera.Service;
 
 import org.springframework.core.io.Resource;
 import yeonjeans.saera.domain.statement.Statement;
-import yeonjeans.saera.domain.statement.Tag;
+import yeonjeans.saera.dto.StateListItemDto;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public interface StatementService {
 
-    Optional<Statement> searchById(Long id);
-    Tag searchByTag(String tag);
-    List<Statement> searchByContent(String content);
+    Statement searchById(Long id);
+    List<StateListItemDto> search(String content, ArrayList<String> tags);
 
     List<Statement> getList();
 

--- a/src/main/java/yeonjeans/saera/Service/StatementServiceImpl.java
+++ b/src/main/java/yeonjeans/saera/Service/StatementServiceImpl.java
@@ -4,14 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import yeonjeans.saera.domain.statement.Statement;
-import yeonjeans.saera.domain.statement.StatementRepository;
-import yeonjeans.saera.domain.statement.Tag;
-import yeonjeans.saera.domain.statement.TagRepository;
+import yeonjeans.saera.domain.statement.*;
+import yeonjeans.saera.dto.StateListItemDto;
 import yeonjeans.saera.exception.CustomException;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static yeonjeans.saera.exception.ErrorCode.STATEMENT_NOT_FOUND;
 
@@ -23,18 +24,34 @@ public class StatementServiceImpl implements StatementService {
     private final WebClient webClient;
 
     @Override
-    public Optional<Statement> searchById(Long id) {
-        return statementRepository.findById(id);
+    public Statement searchById(Long id) {
+        return statementRepository.findById(id).orElseThrow(()->new CustomException(STATEMENT_NOT_FOUND));
     }
 
-    @Override
-    public List<Statement> searchByContent(String content) {
-        return statementRepository.findByContentContaining(content);
+    public List<StateListItemDto> search(String content, ArrayList<String> tags){
+        if(content==null&&tags==null){
+            return statementRepository.findAll()
+                    .stream().map(StateListItemDto::new).collect(Collectors.toList());
+        }else if(content!=null&&tags!=null){
+            return Stream.concat(statementRepository.findByContentContaining(content).stream(), searchByTagList(tags))
+                    .distinct()
+                    .map(StateListItemDto::new)
+                    .collect(Collectors.toList());
+
+        }else if(content!=null){
+            return statementRepository.findByContentContaining(content).stream().map(StateListItemDto::new).collect(Collectors.toList());
+        }else{
+            return searchByTagList(tags).map(StateListItemDto::new).collect(Collectors.toList());
+        }
+
     }
 
-    @Override
-    public Tag searchByTag(String tag) {
-        return tagRepository.findByName(tag);
+    public Stream<Statement> searchByTagList(ArrayList<String> tags) {
+        return tags.stream().map(tagRepository::findByName)
+                .map(Tag::getStatements)
+            .flatMap(Collection::stream)
+            .map(StatementTag::getStatement)
+            .distinct();
     }
 
     @Override

--- a/src/main/java/yeonjeans/saera/controller/StatementController.java
+++ b/src/main/java/yeonjeans/saera/controller/StatementController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,26 +14,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import yeonjeans.saera.Service.StatementServiceImpl;
+import yeonjeans.saera.Service.StatementService;
 import yeonjeans.saera.domain.statement.Statement;
 import yeonjeans.saera.domain.statement.StatementTag;
 import yeonjeans.saera.domain.statement.Tag;
+import yeonjeans.saera.dto.StateListItemDto;
 import yeonjeans.saera.dto.StatementResponseDto;
 import yeonjeans.saera.exception.CustomException;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static yeonjeans.saera.exception.ErrorCode.STATEMENT_NOT_FOUND;
 
 @RequiredArgsConstructor
 @RestController
 public class StatementController {
 
-    private final StatementServiceImpl statementService;
+    private final StatementService statementService;
 
     @Operation(summary = "문장 세부 조회", description = "statement_id를 이용하여 statement 레코드를 단건 조회합니다.", tags = { "Statement Controller" },
             responses = {
@@ -43,11 +38,9 @@ public class StatementController {
             })
     @GetMapping("/statements/{id}")
     public ResponseEntity<StatementResponseDto> returnStatement(@PathVariable Long id){
-        Statement statement = statementService.searchById(id)
-                .orElseThrow(()->new CustomException(STATEMENT_NOT_FOUND));
+        Statement statement = statementService.searchById(id);
 
-        StatementResponseDto dto = new StatementResponseDto(statement);
-        return ResponseEntity.ok().body(dto);
+        return ResponseEntity.ok().body(new StatementResponseDto(statement));
     }
 
     @Operation(summary = "예시 음성 조회", description = "statement id를 이용하여 예시 음성을 조회 합니다.", tags = { "Statement Controller" },
@@ -71,29 +64,11 @@ public class StatementController {
             }
     )
     @GetMapping("/statements")
-    public ResponseEntity<List<StatementResponseDto>> searchStatement(
+    public ResponseEntity<?> searchStatement(
             @RequestParam(value = "content", required = false) String content,
             @RequestParam(value = "tags", required= false) ArrayList<String> tags
     ){
-        List<StatementResponseDto> list;
-
-        if(content!=null){
-            list = statementService.searchByContent(content).stream()
-                    .map(StatementResponseDto::new)
-                    .collect(Collectors.toList());
-        }else if(tags!=null){
-            list = tags.stream().map(statementService::searchByTag)
-                    .map(Tag::getStatements)
-                    .flatMap(Collection::stream)
-                    .map(StatementTag::getStatement)
-                    .distinct()
-                    .map(StatementResponseDto::new)
-                    .collect(Collectors.toList());
-        }else{
-            list = statementService.getList().stream()
-                    .map(StatementResponseDto::new)
-                    .collect(Collectors.toList());
-        }
+        List<StateListItemDto> list = statementService.search(content, tags);
 
         return ResponseEntity.ok().body(list);
     }

--- a/src/main/java/yeonjeans/saera/domain/practiced/PracticedRepository.java
+++ b/src/main/java/yeonjeans/saera/domain/practiced/PracticedRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yeonjeans.saera.domain.member.Member;
 import yeonjeans.saera.domain.statement.Statement;
 
+import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/yeonjeans/saera/dto/StateListItemDto.java
+++ b/src/main/java/yeonjeans/saera/dto/StateListItemDto.java
@@ -55,4 +55,23 @@ public class StateListItemDto {
             this.practiced = false;
         }
     }
+
+    public StateListItemDto(Statement state){
+        this.content = state.getContent();
+        this.tags = state.getTags().stream()
+                .map(statementTag -> statementTag.getTag().getName())
+                .collect(Collectors.toList());
+        this.statement_id = state.getId();
+        this.bookmarked = state.getBookmarks().stream().anyMatch(i->i.getMember().getId().equals(1L));
+        try{
+            Practiced practiced = state.getPracticeds().stream()
+                    .filter(practice -> practice.getMember().getId().equals(1L))
+                    .findFirst().orElseThrow();
+            this.practiced = true;
+            this.date = practiced.getModifiedDate()!=null? practiced.getModifiedDate() : practiced.getCreatedDate();
+        }catch (NoSuchElementException exception){
+            this.date = null;
+            this.practiced = false;
+        }
+    }
 }


### PR DESCRIPTION
- pitch_graph 데이터 파싱해서 넘겨주기
<img width="397" alt="image" src="https://user-images.githubusercontent.com/68546023/217000833-d36521a3-71be-403c-b69b-049a88a8d807.png">


 - api 요청 시 statement_id로 통일
 -  bookmarked, practiced boolean 값으로 수정
 - 검색 api -> OR 연산으로 수정
<img width="418" alt="image" src="https://user-images.githubusercontent.com/68546023/217000546-dfbfbc97-2e44-4862-a150-f4d0ed771a87.png">




