### PR TITLE
Feat/#19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'yeonjeans'
-version = '0.0.8-SNAPSHOT'
+version = '0.0.9-SNAPSHOT'
 sourceCompatibility = '11'
 
 repositories {

--- a/src/main/java/yeonjeans/saera/Service/MemberService.java
+++ b/src/main/java/yeonjeans/saera/Service/MemberService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import yeonjeans.saera.domain.member.Member;
 import yeonjeans.saera.dto.MemberInfoResponseDto;
 import yeonjeans.saera.dto.TokenResponseDto;
+import yeonjeans.saera.exception.CustomException;
 
 public interface MemberService {
 
@@ -14,7 +15,7 @@ public interface MemberService {
     TokenResponseDto login(Member request);
 
     @Transactional
-    public JSONObject reIssueToken(String refreshToken);
+    public TokenResponseDto reIssueToken(String refreshToken);
 
     public MemberInfoResponseDto getMemberInfo(Long memberId);
 }

--- a/src/main/java/yeonjeans/saera/config/SecurityConfig.java
+++ b/src/main/java/yeonjeans/saera/config/SecurityConfig.java
@@ -25,11 +25,9 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
 
-    private final MemberService memberService;
-
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter(){
-        return new JwtAuthenticationFilter(tokenProvider, memberService);
+        return new JwtAuthenticationFilter(tokenProvider);
     }
 
     @Bean
@@ -51,8 +49,8 @@ public class SecurityConfig {
 //        http
 //                .exceptionHandling()
 //                .authenticationEntryPoint(customAuthenticationEntryPoint);
-        http.formLogin();
-        http.oauth2Login();
+ //       http.formLogin();
+  //     http.oauth2Login();
         http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
@@ -61,8 +59,8 @@ public class SecurityConfig {
                 .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
 
         http.authorizeRequests()
-                .antMatchers("/bookmark**", "/bookmark/**", "/statements**", "/statements/**", "/practiced**", "/practiced/**", "/search").authenticated()
-                .anyRequest().permitAll();
+                .antMatchers("/test/**", "/reissue-token", "/auth/**").permitAll()
+                .anyRequest().authenticated();
 
         return http.build();
     }

--- a/src/main/java/yeonjeans/saera/controller/AuthController.java
+++ b/src/main/java/yeonjeans/saera/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import yeonjeans.saera.Service.MemberService;
+import yeonjeans.saera.Service.MemberServiceImpl;
 import yeonjeans.saera.domain.member.Member;
 import yeonjeans.saera.domain.member.MemberRepository;
 import yeonjeans.saera.domain.member.Platform;
@@ -22,11 +23,15 @@ import yeonjeans.saera.dto.MemberInfoResponseDto;
 import yeonjeans.saera.dto.StateListItemDto;
 import yeonjeans.saera.dto.TokenResponseDto;
 import yeonjeans.saera.dto.oauth.GoogleUser;
+import yeonjeans.saera.exception.CustomException;
+import yeonjeans.saera.exception.ErrorCode;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
+import yeonjeans.saera.security.jwt.TokenProvider;
 import yeonjeans.saera.security.service.OAuthService;
 
 
+import javax.validation.Valid;
 import java.util.List;
 
 @Log4j2
@@ -37,8 +42,10 @@ public class AuthController {
     private final OAuthService oAuthService;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final MemberServiceImpl memberServiceImpl;
 
-    @Operation(summary = "토큰 요청", description = "구글 Server Auth Code를 통해 유저 정보를 받아오고, 토큰 발급합니다.",
+    @Operation(summary = "토큰 발급", description = "구글 Server Auth Code를 통해 유저 정보를 받아오고, 토큰 발급합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = TokenResponseDto.class)))
             }
@@ -66,19 +73,53 @@ public class AuthController {
         return ResponseEntity.ok().body(dto);
     }
 
-    @Operation(summary = "유저 정보 조회", description = "Token을 이용하여 유저 정보 조회",
+    @Operation(summary = "유저 정보 조회", description = "Access Token을 이용하여 유저 정보 조회",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = MemberInfoResponseDto.class)))}),
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = MemberInfoResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/member")
-    public ResponseEntity<?> returnBookmarkList(@RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> returnMemberInfo(@RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
         MemberInfoResponseDto dto = memberService.getMemberInfo(principal.getId());
         return ResponseEntity.ok().body(dto);
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 이용하여 AccessToken, RefreshToken을 재발급합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = TokenResponseDto.class)))}),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @GetMapping("/reissue-token")
+    public ResponseEntity<?> reissueToken(@Valid @RequestHeader(required = true) String refreshToken){
+        if (refreshToken.length() > 7 && refreshToken.startsWith("Bearer")) {
+            TokenResponseDto dto = memberService.reIssueToken(refreshToken.substring(7));
+            return ResponseEntity.ok().body(dto);
+        }
+        throw new CustomException(ErrorCode.BEARER_ERROR);
+    }
+
+    @GetMapping("test/accessToken")
+    public ResponseEntity<?> testAuthToken(@RequestParam(required = true) String email){
+        Member member = memberRepository.findByEmail(email, Platform.GOOGLE).orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        String token = tokenProvider.createAccessTokenForTest(member.getId(), member.getNickname());
+        return ResponseEntity.ok().body(token);
+    }
+
+    @GetMapping("test/refreshToken")
+    public ResponseEntity<?> testRefreshToken(@RequestParam(required = true) String email){
+        Member member = memberRepository.findByEmail(email, Platform.GOOGLE).orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        String token = tokenProvider.createRefreshTokenForTest(member.getId());
+
+        memberServiceImpl.saveRefreshToken(member, token);
+        return ResponseEntity.ok().body(token);
     }
 }

--- a/src/main/java/yeonjeans/saera/controller/BookmarkController.java
+++ b/src/main/java/yeonjeans/saera/controller/BookmarkController.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import yeonjeans.saera.Service.BookmarkServiceImpl;
 import yeonjeans.saera.dto.StateListItemDto;
-import yeonjeans.saera.dto.StatementResponseDto;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
 
@@ -26,13 +25,14 @@ public class BookmarkController {
 
     @Operation(summary = "즐겨찾기 문장 조회", description = "즐겨찾기 된 문장 리스트가 제공됩니다.", tags = { "Bookmark Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StatementResponseDto.class)))}),
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StateListItemDto.class)))}),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/bookmark")
-    public ResponseEntity<?> returnBookmarkList(@RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> returnBookmarkList(@RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -42,13 +42,14 @@ public class BookmarkController {
 
     @Operation(summary = "즐겨찾기 생성", description = "statement_id를 사용하여 bookmark를 등록합니다.", tags = { "Bookmark Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @PostMapping("/bookmark/{id}")
-    public ResponseEntity<?> createBookmark(@PathVariable Long id, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> createBookmark(@PathVariable Long id, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -58,13 +59,14 @@ public class BookmarkController {
 
     @Operation(summary = "즐겨찾기 삭제", description = "statement_id를 사용하여 Bookmark를 삭제합니다.", tags = { "Bookmark Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "200", description = "삭제 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             }
     )
     @DeleteMapping("/bookmark/{id}")
-    public ResponseEntity<?> deleteBookmark(@PathVariable Long id, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> deleteBookmark(@PathVariable Long id, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 

--- a/src/main/java/yeonjeans/saera/controller/PracticedController.java
+++ b/src/main/java/yeonjeans/saera/controller/PracticedController.java
@@ -33,11 +33,12 @@ public class PracticedController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StateListItemDto.class)))}),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-        }
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    }
     )
     @GetMapping("/practiced")
-    public ResponseEntity<?> returnPracticedList(@RequestHeader String authorization, @RequestHeader String RefreshToken) {
+    public ResponseEntity<?> returnPracticedList(@RequestHeader String authorization) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -47,13 +48,14 @@ public class PracticedController {
 
     @Operation(summary = "유저 음성 파일 조회", description = "statement_id를 통해 유저의 음성 녹음 파일을 제공합니다.", tags = { "Practiced Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticedResponseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/practiced/record/{id}")
-    public ResponseEntity returnPracticedRecord(@PathVariable(required = false) Long id, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity returnPracticedRecord(@PathVariable Long id, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -69,11 +71,12 @@ public class PracticedController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticedResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/practiced/{id}")
-    public ResponseEntity<?> returnPracticed(@PathVariable(required = false) Long id, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> returnPracticed(@PathVariable Long id, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -82,14 +85,15 @@ public class PracticedController {
         return ResponseEntity.ok().body(dto);
     }
 
-    @Operation(summary = "학습 정보 생성", description = "statement_id를 사용하여 학습 정보 생성합니다.", tags = { "Practiced Controller" },
+    @Operation(summary = "학습 정보 생성", description = "문장 id를 사용하여 학습 정보를 생성합니다.", tags = { "Practiced Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticedResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/practiced", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> createPracticed(@ModelAttribute PracticedRequestDto requestDto, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> createPracticed(@ModelAttribute PracticedRequestDto requestDto, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 

--- a/src/main/java/yeonjeans/saera/controller/StatementController.java
+++ b/src/main/java/yeonjeans/saera/controller/StatementController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import yeonjeans.saera.Service.MemberService;
 import yeonjeans.saera.Service.StatementService;
 import yeonjeans.saera.domain.member.Member;
 import yeonjeans.saera.domain.member.MemberRepository;
@@ -39,10 +38,11 @@ public class StatementController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = StatementResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/statements/{id}")
-    public ResponseEntity<StatementResponseDto> returnStatement(@PathVariable Long id, @RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<StatementResponseDto> returnStatement(@PathVariable Long id, @RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
@@ -53,8 +53,9 @@ public class StatementController {
 
     @Operation(summary = "예시 음성 조회", description = "statement id를 이용하여 예시 음성을 조회 합니다.", tags = { "Statement Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = StatementResponseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/statements/record/{id}")
     public ResponseEntity<?> getExampleRecord(@PathVariable Long id){
@@ -68,15 +69,16 @@ public class StatementController {
 
     @Operation(summary = "문장 검색", description = "문장 내용(content)나 tag이름을 이용하여 문장리스트를 검색합니다.", tags = { "Statement Controller" },
             responses = {
-                @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StatementResponseDto.class)))}),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StateListItemDto.class)))}),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         }
     )
     @GetMapping("/statements")
     public ResponseEntity<?> searchStatement(
             @RequestParam(value = "content", required = false) String content,
             @RequestParam(value = "tags", required= false) ArrayList<String> tags,
-            @RequestHeader String authorization, @RequestHeader String RefreshToken
+            @RequestHeader String authorization
     ){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
@@ -88,13 +90,14 @@ public class StatementController {
 
     @Operation(summary = "최근 검색 내역 조회", description = "최근 검색한 문장 3개 제공", tags = { "Statement Controller" },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StatementResponseDto.class)))}),
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = StateListItemDto.class)))}),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/search")
-    public ResponseEntity<?> searchHistory(@RequestHeader String authorization, @RequestHeader String RefreshToken){
+    public ResponseEntity<?> searchHistory(@RequestHeader String authorization){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 

--- a/src/main/java/yeonjeans/saera/domain/practiced/Record.java
+++ b/src/main/java/yeonjeans/saera/domain/practiced/Record.java
@@ -3,10 +3,6 @@ package yeonjeans.saera.domain.practiced;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-import yeonjeans.saera.domain.practiced.Practiced;
-import yeonjeans.saera.domain.statement.Statement;
 
 import javax.persistence.*;
 
@@ -21,7 +17,7 @@ public class Record {
     @Column(nullable = false)
     private String path;
 
-    @Column(columnDefinition =  "LONGBLOB")
+    @Column(columnDefinition = "MEDIUMBLOB")
     private byte[] wavFile;
 
     @Builder

--- a/src/main/java/yeonjeans/saera/exception/ErrorCode.java
+++ b/src/main/java/yeonjeans/saera/exception/ErrorCode.java
@@ -8,12 +8,16 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    /*500*/
     UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ""),
+    COMMUNICATION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "다른 서버와 통신에 실패했습니다."),
     GOOGLE_AUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "구글 서버에서 Token을 받아오는 데 실패했습니다."),
 
+    /*400 BAD_REQUEST*/
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 누락된 값이 없는 지 확인해주세요."),
+
     /* 401 Unauthorized: 인증 실패*/
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 토큰입니다."), //ExceptionHandlerFilter에서 499Code로 리턴됨.
     WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다."),
     REISSUE_FAILURE(HttpStatus.UNAUTHORIZED, "토큰 재발급에 실패했습니다."),
     BEARER_ERROR(HttpStatus.UNAUTHORIZED, "BEARER TOKEN 형식으로 요청해야 합니다."),
@@ -27,7 +31,10 @@ public enum ErrorCode {
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "데이터가 이미 존재합니다"),
-    ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 즐겨찾기 된 문장입니다.");
+    ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 즐겨찾기 된 문장입니다."),
+
+    /*422 Unprocessable Entity :*/
+    UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "그래프 데이터를 받아올 수 없습니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/yeonjeans/saera/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/yeonjeans/saera/exception/ExceptionHandlerFilter.java
@@ -36,7 +36,8 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
         JSONObject responseJson = new JSONObject();
-        responseJson.put("status", errorCode.getHttpStatus().value());
+        if(errorCode == ErrorCode.EXPIRED_TOKEN) responseJson.put("status", 499);
+        else responseJson.put("status", errorCode.getHttpStatus().value());
         responseJson.put("error", errorCode.getHttpStatus().name());
         responseJson.put("code", errorCode.name());
         responseJson.put("message", errorCode.getDetail());

--- a/src/main/java/yeonjeans/saera/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/yeonjeans/saera/security/jwt/JwtAuthenticationFilter.java
@@ -1,13 +1,10 @@
 package yeonjeans.saera.security.jwt;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONObject;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import yeonjeans.saera.Service.MemberService;
 import yeonjeans.saera.exception.CustomException;
 import yeonjeans.saera.exception.ErrorCode;
 
@@ -20,35 +17,19 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
-    private final MemberService memberService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String accessToken = resolveAccessToken(request);
-        String refreshToken = resolveRefreshToken(request);
+        String accessToken = resolveToken(request);
 
-        if (accessToken != null && refreshToken != null) {
-            try {
-                tokenProvider.validateToken(accessToken);
-            } catch (ExpiredJwtException e) {
-                logger.info(e);
-                tokenProvider.validateToken(refreshToken);
-                JSONObject reissued = memberService.reIssueToken(refreshToken);
-
-                response.setStatus(499);
-                response.setContentType("application/json");
-                response.setCharacterEncoding("UTF-8");
-                response.getWriter().print(reissued);
-                return;
-            }
-
+        if(accessToken != null) {
             Authentication authentication = tokenProvider.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(request, response);
     }
 
-    private String resolveAccessToken(HttpServletRequest request) {
+    private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (!StringUtils.hasText(bearerToken)) return null;
 
@@ -57,15 +38,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         throw new CustomException(ErrorCode.BEARER_ERROR);
     }
-
-    private String resolveRefreshToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("RefreshToken");
-        if (!StringUtils.hasText(bearerToken)) return null;
-
-        if (bearerToken.length() > 7 && bearerToken.startsWith("Bearer")) {
-            return bearerToken.substring(7);
-        }
-        throw new CustomException(ErrorCode.BEARER_ERROR);
-    }
-
 }


### PR DESCRIPTION
- /reissue-token
    - Authorization에 AT보내지 않도록 유의해주세요
    
- test를 위한 토큰발급 api 만들었어요
    - /test/accessToken
        - (대문자봐주세여^_^;; 자바하다가 까묵음..)
        - accessToken(3분)만 발급됨.
        - email입력하면 알아서 id찾아서 발급됨
    - /test/RefreshToken
        - refreshToken(5분)만 발급됨.
        - email입력하면 알아서.. Login Table에도 저장됨.
    - accessToken은 만료되지 않으면 계속 쓸 수 있지만, refreshToken은 가장 최신의 것만 사용가능함.
    - test용으로 만든거라 클라이언트 token 재발급 관련 issue 끝나면 없어질 예정.
    
- ML서버 보안 업뎃
    - 학습정보 생성 이제 됨
    - 조용한 음성오류 422 return
    - 그 외 ML 서버와 통신 오류일경우
        → 500+”타 서버와 통신에 실패했습니다” message.
        
- tts 음성 요청 → clova로 변경
    - client 쪽 변경 사항 없습니다.