### PR TITLE
Feat/#37

### DIFF
--- a/src/main/java/yeonjeans/saera/Service/CustomServiceImpl.java
+++ b/src/main/java/yeonjeans/saera/Service/CustomServiceImpl.java
@@ -22,6 +22,7 @@ import yeonjeans.saera.domain.repository.custom.CTagRepository;
 import yeonjeans.saera.domain.repository.custom.CustomCTagRepository;
 import yeonjeans.saera.domain.repository.custom.CustomRepository;
 import yeonjeans.saera.domain.repository.member.MemberRepository;
+import yeonjeans.saera.dto.CustomListItemDto;
 import yeonjeans.saera.dto.ListItemDto;
 import yeonjeans.saera.dto.NameIdDto;
 import yeonjeans.saera.dto.CustomResponseDto;
@@ -83,10 +84,11 @@ public class CustomServiceImpl {
 
         List<CTag> tagList = tags.stream().map(ctag->saveTag(ctag, member)).collect(Collectors.toList());
 
-        List<CustomCtag> relrationList = tagList.stream().map(cTag -> new CustomCtag(custom, cTag)).collect(Collectors.toList());
-        customCTagRepository.saveAll(relrationList);
+        List<CustomCtag> relationList = tagList.stream().map(cTag -> new CustomCtag(custom, cTag)).collect(Collectors.toList());
+        customCTagRepository.saveAll(relationList);
 
-        return new CustomResponseDto(customRepository.save(custom));
+        Boolean isDuplicate = customRepository.existsByContentAndIsPublicTrue(content);
+        return new CustomResponseDto(customRepository.save(custom), isDuplicate);
     }
 
     @Transactional
@@ -116,6 +118,21 @@ public class CustomServiceImpl {
     }
 
     public CustomResponseDto read(Long id, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Object[]> list = customRepository.findByIdWithBookmarkAndPractice(member, id);
+        if(list.isEmpty()) throw new CustomException(CUSTOM_NOT_FOUND);
+        Object[] result = list.get(0);
+
+        Custom custom = result[0] instanceof Custom ? ((Custom) result[0]) : null;
+        Bookmark bookmark = result[1] instanceof Bookmark ? ((Bookmark) result[1]) : null;
+        Practice practice = result[2] instanceof Practice ? ((Practice) result[2]) : null;
+
+        return new CustomResponseDto(custom, bookmark, practice);
+    }
+
+    public CustomResponseDto setPublic(Long id, Long memberId){
         Member member = memberRepository.findById(memberId).orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Object[]> list = customRepository.findByIdWithBookmarkAndPractice(member, id);
@@ -125,6 +142,9 @@ public class CustomServiceImpl {
         Custom custom = result[0] instanceof Custom ? ((Custom) result[0]) : null;
         Bookmark bookmark = result[1] instanceof Bookmark ? ((Bookmark) result[1]) : null;
         Practice practice = result[2] instanceof Practice ? ((Practice) result[2]) : null;
+
+        custom.setIsPublic(Boolean.TRUE);
+        customRepository.save(custom);
 
         return new CustomResponseDto(custom, bookmark, practice);
     }
@@ -184,7 +204,7 @@ public class CustomServiceImpl {
         return audioBytes;
     }
 
-    public List<ListItemDto> getCustoms(boolean bookmarked, String content, ArrayList<String> tags, Long memberId) {
+    public List<CustomListItemDto> getCustoms(boolean bookmarked, String content, ArrayList<String> tags, Long memberId) {
     Member member = memberRepository.findById(memberId).orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         Stream<Object[]> stream;
@@ -199,6 +219,19 @@ public class CustomServiceImpl {
             stream = customRepository.findAllByContentContaining(member,'%'+content+'%').stream();
         }else{
             stream = searchByTagList(tags, member);
+        }
+        return stream.map(CustomListItemDto::new).collect(Collectors.toList());
+    }
+
+    public List<ListItemDto> getPublicCustoms(String content, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Stream<Object[]> stream;
+        if (content == null) {
+            stream = customRepository.findAllByIsPublicTrueWithBookmarkAndPractice(member).stream();
+        } else {
+            stream = customRepository.findAllByIsPublicTrueAndContentContaining(member, '%'+content+'%').stream();
         }
         return stream.map(ListItemDto::new).collect(Collectors.toList());
     }

--- a/src/main/java/yeonjeans/saera/Service/CustomServiceImpl.java
+++ b/src/main/java/yeonjeans/saera/Service/CustomServiceImpl.java
@@ -96,7 +96,9 @@ public class CustomServiceImpl {
         Member member = memberRepository.findById(memberId).orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         Custom custom = customRepository.findById(fk).orElseThrow(()-> new CustomException(ErrorCode.CUSTOM_NOT_FOUND));
-
+        if(custom.getIsPublic()){
+            throw new CustomException(ErrorCode.PUBLIC_CANT_DEL);
+        }
         List<CustomCtag> ctList = customCTagRepository.findAllByCustom(custom);
         customCTagRepository.deleteAll(ctList);
 

--- a/src/main/java/yeonjeans/saera/config/AppConfig.java
+++ b/src/main/java/yeonjeans/saera/config/AppConfig.java
@@ -9,7 +9,7 @@ public class AppConfig {
 
     @Bean
     public String MLserverBaseUrl(){
-        return "http://34.64.207.59/";
+        return "http://34.64.46.101/";
     }
 
     @Bean

--- a/src/main/java/yeonjeans/saera/config/SecurityConfig.java
+++ b/src/main/java/yeonjeans/saera/config/SecurityConfig.java
@@ -48,8 +48,8 @@ public class SecurityConfig {
 //        http
 //                .exceptionHandling()
 //                .authenticationEntryPoint(customAuthenticationEntryPoint);
-//        http.formLogin();
-//        http.oauth2Login();
+        http.formLogin();
+        http.oauth2Login();
         http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
@@ -59,8 +59,10 @@ public class SecurityConfig {
                 .addFilterBefore(loggingFilter, exceptionHandlerFilter.getClass());
 
         http.authorizeRequests()
-                .antMatchers("/top5-statement", "/reissue-token", "/word-id", "/words/record/**", "/statements/record/**", "/today-list", "/auth/**").permitAll()
-                .antMatchers( "/swagger-ui/*").permitAll()
+                .antMatchers("/auth/**").permitAll()
+                .antMatchers("/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated();
 
         return http.build();

--- a/src/main/java/yeonjeans/saera/config/SwaggerConfig.java
+++ b/src/main/java/yeonjeans/saera/config/SwaggerConfig.java
@@ -1,0 +1,15 @@
+package yeonjeans.saera.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        type = SecuritySchemeType.HTTP,
+        name = "bearerAuth",
+        bearerFormat = "JWT",
+        scheme = "bearer")
+public class SwaggerConfig {
+
+}

--- a/src/main/java/yeonjeans/saera/controller/AuthController.java
+++ b/src/main/java/yeonjeans/saera/controller/AuthController.java
@@ -1,0 +1,76 @@
+package yeonjeans.saera.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import yeonjeans.saera.Service.MemberService;
+import yeonjeans.saera.domain.entity.member.Member;
+import yeonjeans.saera.domain.entity.member.Platform;
+import yeonjeans.saera.domain.repository.member.MemberRepository;
+import yeonjeans.saera.dto.TokenResponseDto;
+import yeonjeans.saera.dto.oauth.GoogleUser;
+import yeonjeans.saera.exception.CustomException;
+import yeonjeans.saera.exception.ErrorCode;
+import yeonjeans.saera.exception.ErrorResponse;
+import yeonjeans.saera.security.service.OAuthService;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final OAuthService oAuthService;
+
+    @Operation(summary = "토큰 발급", description = "구글 Server Auth Code를 통해 유저 정보를 받아오고, 토큰 발급합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = TokenResponseDto.class)))
+            }
+    )
+    @GetMapping(value = "/auth/google/callback")
+    public ResponseEntity<?> callback(
+            @RequestParam(name = "code") String code) {
+
+        GoogleUser userInfo = oAuthService.getUserInfo(Platform.GOOGLE, code);
+
+        Member member;
+        TokenResponseDto dto;
+        Boolean isExist = memberRepository.existsByEmailAndPlatform(userInfo.getEmail(), Platform.GOOGLE);
+
+        //login
+        if(isExist){
+            member = memberRepository.findByEmailAndPlatform(userInfo.getEmail(), Platform.GOOGLE).get();
+            dto = memberService.login(member);
+        }
+        //join
+        else{
+            member = userInfo.toMember();
+            dto = memberService.join(member);
+        }
+        return ResponseEntity.ok().body(dto);
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 이용하여 AccessToken, RefreshToken을 재발급합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = TokenResponseDto.class)))}),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @GetMapping("/reissue-token")
+    public ResponseEntity<?> reissueToken(@RequestHeader(required = true) String refreshToken){
+        if (refreshToken.length() > 7 && refreshToken.startsWith("Bearer")) {
+            TokenResponseDto dto = memberService.reIssueToken(refreshToken.substring(7));
+            return ResponseEntity.ok().body(dto);
+        }
+        throw new CustomException(ErrorCode.BEARER_ERROR);
+    }
+}

--- a/src/main/java/yeonjeans/saera/controller/BookmarkController.java
+++ b/src/main/java/yeonjeans/saera/controller/BookmarkController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,6 +15,7 @@ import yeonjeans.saera.domain.entity.example.ReferenceType;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
 public class BookmarkController {

--- a/src/main/java/yeonjeans/saera/controller/CustomController.java
+++ b/src/main/java/yeonjeans/saera/controller/CustomController.java
@@ -47,7 +47,26 @@ public class CustomController {
         return ResponseEntity.ok().body(dto);
     }
 
-    @Operation(summary = "사용자 정의 문장 리스트 조회", description = "문장 내용(content)나 tag이름을 이용하여 사용자 정의 문장 리스트를 검색합니다.", tags = { "Custom Controller" },
+    @Operation(summary = "사용자 정의 문장 공개 설정", description = "사용자 정의 문장을 공개 설정합니다.", tags = { "Custom Controller" },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = CustomResponseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @PostMapping("/customs/set-public")
+    public ResponseEntity<?> setPublic(
+            @RequestParam(value = "사용자 정의 문장 id", required = true) Long id,
+            @RequestHeader String Authorization
+    ){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        AuthMember principal = (AuthMember) authentication.getPrincipal();
+
+        CustomResponseDto dto =  customService.setPublic(id, principal.getId());
+        return ResponseEntity.ok().body(dto);
+    }
+
+    @Operation(summary = "사용자 정의 문장 리스트 조회", description = "문장 내용(content)나 tag이름을 이용하여 사용자 정의 문장 리스트를 조회합니다.", tags = { "Custom Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = ListItemDto.class)))}),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -56,6 +75,7 @@ public class CustomController {
     )
     @GetMapping("/customs")
     public ResponseEntity<?> returnCustomList(
+            @RequestParam(value = "isPublic", defaultValue = "false") boolean isPublic,
             @RequestParam(value = "bookmarked", defaultValue = "false") boolean bookmarked,
             @RequestParam(value = "content", required = false) String content,
             @RequestParam(value = "tags", required= false) ArrayList<String> tags,
@@ -64,13 +84,18 @@ public class CustomController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
-        List<ListItemDto> list;
-        list = customService.getCustoms(bookmarked, content, tags, principal.getId());
+        if(isPublic){
+            List<ListItemDto> list;
+            list = customService.getPublicCustoms(content, principal.getId());
+            return ResponseEntity.ok().body(list);
+        }
 
+        List<CustomListItemDto> list;
+        list = customService.getCustoms(bookmarked, content, tags, principal.getId());
         return ResponseEntity.ok().body(list);
     }
 
-    @Operation(summary = "사용자 정의 문장 조회", description = "문장 내용(content), tag들을 이용해 사용자 정의 문장을 생성합니다.", tags = { "Custom Controller" },
+    @Operation(summary = "사용자 정의 문장 조회", description = "문장 내용(content), tag들을 이용해 사용자 정의 문장을 조회합니다.", tags = { "Custom Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = CustomResponseDto.class))),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/src/main/java/yeonjeans/saera/controller/CustomController.java
+++ b/src/main/java/yeonjeans/saera/controller/CustomController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -21,6 +22,7 @@ import yeonjeans.saera.security.dto.AuthMember;
 import java.util.ArrayList;
 import java.util.List;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
 public class CustomController {

--- a/src/main/java/yeonjeans/saera/controller/MemberController.java
+++ b/src/main/java/yeonjeans/saera/controller/MemberController.java
@@ -1,66 +1,27 @@
 package yeonjeans.saera.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import yeonjeans.saera.Service.MemberService;
-import yeonjeans.saera.domain.entity.member.Member;
-import yeonjeans.saera.domain.repository.member.MemberRepository;
-import yeonjeans.saera.domain.entity.member.Platform;
 import yeonjeans.saera.dto.MemberInfoResponseDto;
 import yeonjeans.saera.dto.PracticeDaysResponseDto;
-import yeonjeans.saera.dto.TokenResponseDto;
-import yeonjeans.saera.dto.oauth.GoogleUser;
-import yeonjeans.saera.exception.CustomException;
-import yeonjeans.saera.exception.ErrorCode;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
-import yeonjeans.saera.security.service.OAuthService;
 
-@Log4j2
 @RequiredArgsConstructor
 @RestController
+@SecurityRequirement(name = "bearerAuth")
 public class MemberController {
 
-    private final OAuthService oAuthService;
     private final MemberService memberService;
-    private final MemberRepository memberRepository;
-
-    @Operation(summary = "토큰 발급", description = "구글 Server Auth Code를 통해 유저 정보를 받아오고, 토큰 발급합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = TokenResponseDto.class)))
-            }
-    )
-    @GetMapping(value = "/auth/google/callback")
-    public ResponseEntity<?> callback(
-            @RequestParam(name = "code") String code) {
-
-        GoogleUser userInfo = oAuthService.getUserInfo(Platform.GOOGLE, code);
-
-        Member member;
-        TokenResponseDto dto;
-        Boolean isExist = memberRepository.existsByEmailAndPlatform(userInfo.getEmail(), Platform.GOOGLE);
-
-        //login
-        if(isExist){
-            member = memberRepository.findByEmailAndPlatform(userInfo.getEmail(), Platform.GOOGLE).get();
-            dto = memberService.login(member);
-        }
-        //join
-        else{
-            member = userInfo.toMember();
-            dto = memberService.join(member);
-        }
-        return ResponseEntity.ok().body(dto);
-    }
 
     @Operation(summary = "유저 정보 조회", description = "Access Token을 이용하여 유저 정보 조회",
             responses = {
@@ -114,22 +75,5 @@ public class MemberController {
 
         PracticeDaysResponseDto dto = memberService.getPracticeDays(principal.getId());
         return ResponseEntity.ok().body(dto);
-    }
-
-    @Operation(summary = "토큰 재발급", description = "Refresh Token을 이용하여 AccessToken, RefreshToken을 재발급합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(array = @ArraySchema(schema = @Schema(implementation = TokenResponseDto.class)))}),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "499", description = "토큰 만료로 인한 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-            }
-    )
-    @GetMapping("/reissue-token")
-    public ResponseEntity<?> reissueToken(@RequestHeader(required = true) String refreshToken){
-        if (refreshToken.length() > 7 && refreshToken.startsWith("Bearer")) {
-            TokenResponseDto dto = memberService.reIssueToken(refreshToken.substring(7));
-            return ResponseEntity.ok().body(dto);
-        }
-        throw new CustomException(ErrorCode.BEARER_ERROR);
     }
 }

--- a/src/main/java/yeonjeans/saera/controller/PracticeController.java
+++ b/src/main/java/yeonjeans/saera/controller/PracticeController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -20,8 +21,10 @@ import yeonjeans.saera.dto.PracticeResponseDto;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
+@SecurityRequirement(name = "bearerAuth")
 public class PracticeController {
     private final PracticeServiceImpl practicedService;
 

--- a/src/main/java/yeonjeans/saera/controller/StatementController.java
+++ b/src/main/java/yeonjeans/saera/controller/StatementController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -23,6 +24,7 @@ import yeonjeans.saera.security.dto.AuthMember;
 import java.util.ArrayList;
 import java.util.List;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
 public class StatementController {

--- a/src/main/java/yeonjeans/saera/controller/StudyController.java
+++ b/src/main/java/yeonjeans/saera/controller/StudyController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -20,6 +21,7 @@ import yeonjeans.saera.security.dto.AuthMember;
 import java.util.ArrayList;
 import java.util.List;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
 public class StudyController {

--- a/src/main/java/yeonjeans/saera/controller/WordController.java
+++ b/src/main/java/yeonjeans/saera/controller/WordController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -20,9 +21,9 @@ import yeonjeans.saera.dto.WordResponseDto;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
 
-import java.util.ArrayList;
 import java.util.List;
 
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
 public class WordController {

--- a/src/main/java/yeonjeans/saera/domain/entity/custom/Custom.java
+++ b/src/main/java/yeonjeans/saera/domain/entity/custom/Custom.java
@@ -24,6 +24,9 @@ public class Custom {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private Boolean isPublic;
+
     @Column(columnDefinition = "MEDIUMBLOB")
     private byte[] file;
 
@@ -49,5 +52,10 @@ public class Custom {
         this.pitchY = pitchY;
         this.file = file;
         this.member = member;
+        this.isPublic = false;
+    }
+
+    public void setIsPublic(Boolean isPublic){
+        this.isPublic = isPublic;
     }
 }

--- a/src/main/java/yeonjeans/saera/domain/repository/custom/CustomRepository.java
+++ b/src/main/java/yeonjeans/saera/domain/repository/custom/CustomRepository.java
@@ -51,4 +51,22 @@ public interface CustomRepository extends JpaRepository<Custom, Long> {
             "JOIN CustomCtag ct ON c.id = ct.custom.id AND ct.tag.id IN "+
             "(SELECT t.id FROM CTag t WHERE t.name IN :tagnameList)")
     List<Long> findAllByTagnameIn(@Param("tagnameList") ArrayList<String> tagnameList);
+
+
+    Boolean existsByContentAndIsPublicTrue(String content);
+
+    @Query("SELECT c, b, p " +
+            "FROM Custom c " +
+            "LEFT JOIN Bookmark b ON c.id = b.fk AND b.type = 2 AND b.member = :member " +
+            "LEFT JOIN Practice p ON c.id = p.fk AND p.type = 2 AND p.member = :member " +
+            "WHERE c.isPublic = true")
+    List<Object[]> findAllByIsPublicTrueWithBookmarkAndPractice(@Param("member")Member member);
+
+
+    @Query("SELECT c, b, p " +
+            "FROM Custom c " +
+            "LEFT JOIN Bookmark b ON c.id = b.fk AND b.type = 2 AND b.member = :member " +
+            "LEFT JOIN Practice p ON c.id = p.fk AND p.type = 2 AND p.member = :member " +
+            "WHERE c.content LIKE :content AND c.isPublic = true")
+    List<Object[]> findAllByIsPublicTrueAndContentContaining(@Param("member")Member member, @Param("content") String content);
 }

--- a/src/main/java/yeonjeans/saera/dto/CustomListItemDto.java
+++ b/src/main/java/yeonjeans/saera/dto/CustomListItemDto.java
@@ -1,0 +1,42 @@
+package yeonjeans.saera.dto;
+
+import lombok.Data;
+import yeonjeans.saera.domain.entity.Bookmark;
+import yeonjeans.saera.domain.entity.Practice;
+import yeonjeans.saera.domain.entity.custom.Custom;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class CustomListItemDto {
+    private String content;
+    private List<String> tags;
+    private LocalDateTime date;
+
+    private Long id;
+    private Boolean practiced;
+    private Boolean bookmarked;
+    private Boolean recommended;
+    private Boolean isPublic;
+
+    public CustomListItemDto(Object[] result) {
+        Bookmark bookmark = result[1] instanceof Bookmark ? ((Bookmark) result[1]) : null;
+        Practice practice = result[2] instanceof Practice ? ((Practice) result[2]) : null;
+        this.practiced = practice != null;
+        this.bookmarked = bookmark != null;
+        this.recommended = false;
+
+        this.date = practiced ? practice.getModifiedDate() : null;
+
+        Custom custom = ((Custom) result[0]);
+
+        this.id = custom.getId();
+        this.content = custom.getContent();
+        this.tags = custom.getTags().stream()
+                .map(customCtag -> customCtag.getTag().getName())
+                .collect(Collectors.toList());
+        this.isPublic = custom.getIsPublic();
+    }
+}

--- a/src/main/java/yeonjeans/saera/dto/CustomResponseDto.java
+++ b/src/main/java/yeonjeans/saera/dto/CustomResponseDto.java
@@ -19,6 +19,7 @@ public class CustomResponseDto {
     List<String> tags;
     private Boolean bookmarked;
     private Boolean practiced;
+    private Boolean isDuplicate;
 
     public CustomResponseDto(Custom custom, Bookmark bookmark, Practice practice){
         this.id = custom.getId();
@@ -33,7 +34,7 @@ public class CustomResponseDto {
         this.practiced = practice != null;
     }
 
-    public CustomResponseDto(Custom custom){
+    public CustomResponseDto(Custom custom, Boolean isDuplicate){
         this.id = custom.getId();
         this.content = custom.getContent();
         this.pitch_x = Parsing.stringToIntegerArray(custom.getPitchX());
@@ -43,5 +44,6 @@ public class CustomResponseDto {
 //              .collect(Collectors.toList());
         bookmarked = false;
         practiced = false;
+        this.isDuplicate = isDuplicate;
     }
 }

--- a/src/main/java/yeonjeans/saera/dto/ListItemDto.java
+++ b/src/main/java/yeonjeans/saera/dto/ListItemDto.java
@@ -44,9 +44,7 @@ public class ListItemDto {
 
             this.id = custom.getId();
             this.content = custom.getContent();
-            this.tags = custom.getTags().stream()
-                    .map(customCtag -> customCtag.getTag().getName())
-                    .collect(Collectors.toList());
+            this.tags = null;
         }
     }
 

--- a/src/main/java/yeonjeans/saera/exception/ErrorCode.java
+++ b/src/main/java/yeonjeans/saera/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     /*400 BAD_REQUEST*/
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 누락된 값이 없는 지 확인해주세요."),
+    PUBLIC_CANT_DEL(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 공개된 사용자 정의 문장은 삭제할 수 없습니다."),
 
     /* 401 Unauthorized: 인증 실패*/
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 토큰입니다."), //ExceptionHandlerFilter에서 499Code로 리턴됨.

--- a/src/main/java/yeonjeans/saera/security/service/GoogleOAuth.java
+++ b/src/main/java/yeonjeans/saera/security/service/GoogleOAuth.java
@@ -20,8 +20,6 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuth implements SocialOAuth {
-    @Value("${social.google.url}")
-    private String GOOGLE_BASE_URL;
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String GOOGLE_CLIENT_ID;
     @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")

--- a/src/test/java/yeonjeans/saera/domain/repository/CustomRepositoryTest.java
+++ b/src/test/java/yeonjeans/saera/domain/repository/CustomRepositoryTest.java
@@ -33,6 +33,15 @@ public class CustomRepositoryTest {
         }
     }
 
+    @Test
+    private void checkDuplicate(){
+        String testContent = "가가";
+        Boolean result = customRepository.existsByContentAndIsPublicTrue(testContent);
+
+        System.out.println(result+"hi");
+        Assertions.assertNotNull(result);
+    }
+
     private void printObject(Object[] objects) {
         System.out.println(objects.length);
 


### PR DESCRIPTION
1. Swagger에 Authorize 버튼 생겼어요..!
    - Bearer 제외하고, AccessToken값 넣으면 됩니당
    - Authorization header가 필요한 각 api에 Authorization input box가 있는데.. 값은 안 넘어 가니, 아무 string 적으면 됩니다 ! (없애면 필요 없는 줄 알까봐 남겨뒀어용.)
    
2. 공개된 문장 리스트
    
    /custom?isPublic=true&&content=””
    
    isPublic=true 넣으면 공개된 문장 리스트
    
    tags = null로 넘어가용
    
    없으면 default false로 본인 문장 (이전과 동일, 문장내용/태그리스트 받음)
    

3. 사용자정의문장 생성 시 중복여부 return
    
    이후 사용자가 공개설정하면 → 4번
    
4. 사용자정의문장 공개 설정
    
    [POST] /custom/set-public
    
    id값 넘겨주세용.
    
5. 사용자 정의 문장 삭제
    
    public설정한 문장 삭제 시, 400 badrequest + msg.
    

**. 참고.. 클로바가 끊겨 있어서 아직 배포는 안했음..