### PR TITLE
Feat/#43

### DIFF
--- a/src/main/java/yeonjeans/saera/Service/PracticeServiceImpl.java
+++ b/src/main/java/yeonjeans/saera/Service/PracticeServiceImpl.java
@@ -49,10 +49,7 @@ public class PracticeServiceImpl implements PracticeService {
     private final WordRepository wordRepository;
     private final CustomRepository customRepository;
 
-    private final WebClient webClient;
-    private final String MLserverBaseUrl;
-    @Value("${ml.secret}")
-    private String ML_SECRET;
+    private final WebClientService webClient;
 
     @Transactional
     public Practice create(PracticeRequestDto dto, Long memberId){
@@ -62,39 +59,20 @@ public class PracticeServiceImpl implements PracticeService {
         Practice practice = practiceRepository.findByMemberAndTypeAndFk(member, dto.getType(), dto.getFk()).orElse(null);
         LocalDate lastPracticeDate = getLastPracticeDate(member);
 
-        //경험치
-        if(practice == null){
-            member.addXp(dto.getType() != ReferenceType.WORD ? XP_STATEMENT : XP_WORD);
-            practice = Practice.builder().member(member).fk(dto.getFk()).type(dto.getType()).build();
-        }else {
-            LocalDate modifiedDate = practice.getModifiedDate().toLocalDate();
-            if(modifiedDate.isEqual(todayDate)){
-                if(!dto.isTodayStudy()) practice.setCount(practice.getCount() + 1);
-            }else{
-                practice.setCount(1);
-            }
-        }
+        updateXp(practice, dto, member, todayDate);
 
         switch (dto.getType()){
             case STATEMENT :
                 createPracticeStatement(dto, practice);
                 break;
-            case WORD:
-                createPracticeWord(dto, practice, todayDate);
-                break;
             case CUSTOM:
                 createPracticeCustom(dto, practice);
                 break;
+            default:
+                throw new CustomException(INVALID_TYPE);
         }
 
-        //연속 학습 일수
-         if(  lastPracticeDate == null || lastPracticeDate.isEqual(todayDate.minusDays(1)) ) {
-            member.setAttendance_count(member.getAttendance_count() + 1);
-            memberRepository.save(member);
-        }else if( !lastPracticeDate.isEqual(todayDate) ){
-            member.setAttendance_count(1);
-            memberRepository.save(member);
-        }
+        updatePracticeDays(member, lastPracticeDate, todayDate);
 
         return practiceRepository.save(practice);
     }
@@ -103,10 +81,10 @@ public class PracticeServiceImpl implements PracticeService {
         Statement state = statementRepository.findById(dto.getFk())
                 .orElseThrow(()->new CustomException(STATEMENT_NOT_FOUND));
 
-        PitchGraphDto userGraph = getPitchGraph(dto.getRecord().getResource());
+        PitchGraphDto userGraph = webClient.getPitchGraph(dto.getRecord().getResource());
         PitchGraphDto targetGraph = new PitchGraphDto(Parsing.stringToIntegerArray(state.getPitchX()), Parsing.stringToDoubleArray(state.getPitchY()));
 
-        Double score = getScore(userGraph, targetGraph);
+        Double score = webClient.getScore(userGraph, targetGraph);
 
         byte[] audioBytes = new byte[0];
         try {
@@ -124,20 +102,39 @@ public class PracticeServiceImpl implements PracticeService {
         practice.setScore(score);
     }
 
-    private void createPracticeWord(PracticeRequestDto dto, Practice practice, LocalDate todayDate) {
+    public Boolean createWord(PracticeRequestDto dto, Long memberId) {
+        if(!dto.getType().equals(ReferenceType.WORD)){
+            throw new CustomException(INVALID_TYPE);
+        }
+
+        LocalDate todayDate = LocalDate.now();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(MEMBER_NOT_FOUND));
+
+        Practice practice = practiceRepository.findByMemberAndTypeAndFk(member, ReferenceType.WORD, dto.getFk()).orElse(null);
+        LocalDate lastPracticeDate = getLastPracticeDate(member);
+
+        updateXp(practice, dto, member, todayDate);
+
         Word word = wordRepository.findById(dto.getFk())
                 .orElseThrow(()->new CustomException(WORD_NOT_FOUND));
+
         practice.setPitchLength(LocalTime.now().getNano());
+
+        practiceRepository.save(practice);
+        updatePracticeDays(member, lastPracticeDate, todayDate);
+
+        return webClient.getWordScore(word.getNotation(), dto.getRecord());
     }
 
     private void  createPracticeCustom(PracticeRequestDto dto, Practice practice) {
         Custom custom = customRepository.findById(dto.getFk())
                 .orElseThrow(()->new CustomException(CUSTOM_NOT_FOUND));
 
-        PitchGraphDto userGraph = getPitchGraph(dto.getRecord().getResource());
+        PitchGraphDto userGraph = webClient.getPitchGraph(dto.getRecord().getResource());
         PitchGraphDto targetGraph = new PitchGraphDto(Parsing.stringToIntegerArray(custom.getPitchX()), Parsing.stringToDoubleArray(custom.getPitchY()));
 
-        Double score = getScore(userGraph, targetGraph);
+        Double score = webClient.getScore(userGraph, targetGraph);
 
         byte[] audioBytes = new byte[0];
         try {
@@ -153,48 +150,6 @@ public class PracticeServiceImpl implements PracticeService {
         practice.setPitchY(userGraph.getPitch_y().toString());
         practice.setPitchLength(userGraph.getPitch_length());
         practice.setScore(score);
-    }
-
-    private PitchGraphDto getPitchGraph(Resource resource){
-        PitchGraphDto graphDto = webClient.post()
-                .uri(MLserverBaseUrl + "pitch-graph")
-                .header("access-token", ML_SECRET)
-                .body(BodyInserters.fromMultipartData("audio", resource))
-                .retrieve()
-                .onStatus(HttpStatus::isError, response -> {
-                    log.error(response.toString());
-                    if(response.statusCode() == HttpStatus.UNPROCESSABLE_ENTITY)
-                        throw new CustomException(ErrorCode.UNPROCESSABLE_ENTITY);
-                    throw new CustomException(ErrorCode.COMMUNICATION_FAILURE);
-                })
-                .bodyToMono(PitchGraphDto.class)
-                .block();
-        return graphDto;
-    }
-
-    private Double getScore(PitchGraphDto userGraph, PitchGraphDto targetGraph ){
-        ScoreRequestDto requestDto = ScoreRequestDto.builder()
-                .target_pitch_x(targetGraph.getPitch_x())
-                .target_pitch_y(targetGraph.getPitch_y())
-                .user_pitch_x(userGraph.getPitch_x())
-                .user_pitch_y(userGraph.getPitch_y())
-                .build();
-
-        String response = webClient.post()
-                .uri(MLserverBaseUrl + "score")
-                .header("access-token", ML_SECRET)
-                .body(BodyInserters.fromValue(requestDto))
-                .retrieve()
-                .onStatus(HttpStatus::isError, res -> {
-                    if(res.statusCode() == HttpStatus.UNPROCESSABLE_ENTITY)
-                        throw new CustomException(ErrorCode.UNPROCESSABLE_ENTITY);
-                    throw new CustomException(ErrorCode.COMMUNICATION_FAILURE);
-                })
-                .bodyToMono(String.class)
-                .block();
-
-        Double score = new JSONObject(response).getDouble("DTW_score");
-        return score;
     }
 
     public PracticeResponseDto read(ReferenceType type, Long fk, Long memberId){
@@ -223,5 +178,30 @@ public class PracticeServiceImpl implements PracticeService {
                         .orElse(null);
 
         return practice != null ? practice.getModifiedDate().toLocalDate() : null;
+    }
+
+    private void updatePracticeDays(Member member, LocalDate lastPracticeDate, LocalDate todayDate){
+        //연속 학습 일수
+        if(  lastPracticeDate == null || lastPracticeDate.isEqual(todayDate.minusDays(1)) ) {
+            member.setAttendance_count(member.getAttendance_count() + 1);
+            memberRepository.save(member);
+        }else if( !lastPracticeDate.isEqual(todayDate) ){
+            member.setAttendance_count(1);
+            memberRepository.save(member);
+        }
+    }
+
+    private void updateXp(Practice practice, PracticeRequestDto dto, Member member, LocalDate todayDate){
+        if(practice == null){
+            member.addXp(dto.getType() != ReferenceType.WORD ? XP_STATEMENT : XP_WORD);
+            practice = Practice.builder().member(member).fk(dto.getFk()).type(dto.getType()).build();
+        }else {
+            LocalDate modifiedDate = practice.getModifiedDate().toLocalDate();
+            if(modifiedDate.isEqual(todayDate)){
+                if(!dto.isTodayStudy()) practice.setCount(practice.getCount() + 1);
+            }else{
+                practice.setCount(1);
+            }
+        }
     }
 }

--- a/src/main/java/yeonjeans/saera/Service/WebClientService.java
+++ b/src/main/java/yeonjeans/saera/Service/WebClientService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StreamUtils;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import yeonjeans.saera.dto.ML.PitchGraphDto;
@@ -56,16 +58,28 @@ public class WebClientService {
         return score;
     }
 
-    public String getWordScore(String notation, Resource resource){
-        String response = webClient.post()
-                .uri(MLserverBaseUrl + "/word-score?target_word="+notation)
-                .header("access-token", ML_SECRET)
-                .body(BodyInserters.fromMultipartData("audio", resource))
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
+    public Boolean getWordScore(String notation, MultipartFile record){
+        try{
+            byte[] audioBytes = StreamUtils.copyToByteArray(record.getInputStream());
+            ByteArrayResource audioResource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() {
+                    return "audio.wav";
+                }
+            };
+            String response = webClient.post()
+                    .uri(MLserverBaseUrl + "/word-score?target_word="+notation)
+                    .header("access-token", ML_SECRET)
+                    .body(BodyInserters.fromMultipartData("audio", audioResource))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
 
-        return response;
+            return new JSONObject(response).getBoolean("result");
+        }catch(IOException ignored){
+
+        }
+            return false;
     }
 
     public PitchGraphDto getPitchGraph(Resource resource){

--- a/src/main/java/yeonjeans/saera/config/SecurityConfig.java
+++ b/src/main/java/yeonjeans/saera/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 //        http
 //                .exceptionHandling()
 //                .authenticationEntryPoint(customAuthenticationEntryPoint);http.formLogin();
-        http.oauth2Login();
+//        http.oauth2Login();
         http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 

--- a/src/main/java/yeonjeans/saera/controller/CustomController.java
+++ b/src/main/java/yeonjeans/saera/controller/CustomController.java
@@ -84,14 +84,14 @@ public class CustomController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AuthMember principal = (AuthMember) authentication.getPrincipal();
 
-        if(isPublic){
-            List<ListItemDto> list;
-            list = customService.getPublicCustoms(content, principal.getId());
-            return ResponseEntity.ok().body(list);
-        }
-
         List<CustomListItemDto> list;
-        list = customService.getCustoms(bookmarked, content, tags, principal.getId());
+        if(isPublic){
+            list = customService.getPublicCustoms(content, principal.getId());
+        }else if(bookmarked){
+            list = customService.getBookmarkedCustoms(principal.getId());
+        }else{
+            list = customService.getCustoms(content, tags, principal.getId());
+        }
         return ResponseEntity.ok().body(list);
     }
 

--- a/src/main/java/yeonjeans/saera/controller/PracticeController.java
+++ b/src/main/java/yeonjeans/saera/controller/PracticeController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import yeonjeans.saera.Service.PracticeServiceImpl;
 import yeonjeans.saera.domain.entity.Practice;
 import yeonjeans.saera.domain.entity.example.ReferenceType;
@@ -21,6 +22,8 @@ import yeonjeans.saera.dto.PracticeResponseDto;
 import yeonjeans.saera.exception.ErrorResponse;
 import yeonjeans.saera.security.dto.AuthMember;
 
+import java.io.IOException;
+
 @SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 @RestController
@@ -28,7 +31,7 @@ import yeonjeans.saera.security.dto.AuthMember;
 public class PracticeController {
     private final PracticeServiceImpl practicedService;
 
-    @Operation(summary = "유저 음성 파일 조회", description = "type과 id를 사용하여 유저의 음성 녹음 파일을 제공합니다.", tags = { "Practiced Controller" },
+    @Operation(summary = "유저 음성 파일 조회", description = "type과 id를 사용하여 유저의 음성 녹음 파일을 제공합니다.", tags = { "Practice Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -50,7 +53,7 @@ public class PracticeController {
         return ResponseEntity.ok().headers(headers).body(resource);
     }
 
-    @Operation(summary = "학습 정보 조회", description = "type과 id를 사용하여 학습정보를 제공합니다..", tags = { "Practiced Controller" },
+    @Operation(summary = "학습 정보 조회", description = "type과 id를 사용하여 학습정보를 제공합니다..", tags = { "Practice Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticeResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -70,9 +73,10 @@ public class PracticeController {
         return ResponseEntity.ok().body(dto);
     }
 
-    @Operation(summary = "학습 정보 생성", description = "type과 id를 사용하여 학습 정보를 생성합니다.", tags = { "Practiced Controller" },
+    @Operation(summary = "학습 정보 생성", description = "type과 id를 사용하여 학습 정보를 생성합니다.", tags = { "Practice Controller" },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticeResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "타입 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "422", description = "음성 파일 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -85,5 +89,22 @@ public class PracticeController {
 
         Practice practice = practicedService.create(requestDto, principal.getId());
         return ResponseEntity.ok().body(new PracticeResponseDto(practice));
+    }
+
+    @Operation(summary = "단어 학습 정보 생성", description = "WORD만 됩니다 !!!!!!!", tags = { "Practice Controller" },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PracticeResponseDto.class))),
+                    @ApiResponse(responseCode = "422", description = "타입 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "422", description = "음성 파일 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    })
+    @PostMapping(value = "/practice-word", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> createPracticeWord(@ModelAttribute PracticeRequestDto dto, @RequestHeader String Authorization) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        AuthMember principal = (AuthMember) authentication.getPrincipal();
+
+        Boolean result = practicedService.createWord(dto, principal.getId());
+
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/src/main/java/yeonjeans/saera/domain/repository/custom/CustomRepository.java
+++ b/src/main/java/yeonjeans/saera/domain/repository/custom/CustomRepository.java
@@ -28,8 +28,16 @@ public interface CustomRepository extends JpaRepository<Custom, Long> {
     @Query("SELECT c, b, p " +
             "FROM Custom c " +
             "JOIN Bookmark b ON c.id = b.fk AND b.type = 2 AND b.member = :member " +
-            "LEFT JOIN Practice p ON c.id = p.fk AND p.type = 2 AND p.member = :member ")
-    List<Object[]> findBookmarkedAllAndPractice(@Param("member") Member member);
+            "LEFT JOIN Practice p ON c.id = p.fk AND p.type = 2 AND p.member = :member "+
+            "WHERE c.member = :member")
+    List<Object[]> findBookmarkedAllwithPractice(@Param("member") Member member);
+
+    @Query("SELECT c, b, p " +
+            "FROM Custom c " +
+            "JOIN Bookmark b ON c.id = b.fk AND b.type = 2 AND b.member = :member " +
+            "LEFT JOIN Practice p ON c.id = p.fk AND p.type = 2 AND p.member = :member "+
+            "WHERE c.member <> :member")
+    List<Object[]> findBookmarkedAllByMemberNotwithPractice(@Param("member") Member member);
 
     @Query("SELECT c, b, p " +
             "FROM Custom c " +

--- a/src/main/java/yeonjeans/saera/dto/CustomListItemDto.java
+++ b/src/main/java/yeonjeans/saera/dto/CustomListItemDto.java
@@ -18,15 +18,33 @@ public class CustomListItemDto {
     private Long id;
     private Boolean practiced;
     private Boolean bookmarked;
-    private Boolean recommended;
     private Boolean isPublic;
+    private Boolean isOwner;
+
+    public CustomListItemDto(Object[] result, boolean isOwner) {
+        Bookmark bookmark = result[1] instanceof Bookmark ? ((Bookmark) result[1]) : null;
+        Practice practice = result[2] instanceof Practice ? ((Practice) result[2]) : null;
+        this.practiced = practice != null;
+        this.bookmarked = bookmark != null;
+
+        this.date = practiced ? practice.getModifiedDate() : null;
+
+        Custom custom = ((Custom) result[0]);
+
+        this.id = custom.getId();
+        this.content = custom.getContent();
+        if(isOwner) this.tags = custom.getTags().stream()
+                .map(customCtag -> customCtag.getTag().getName())
+                .collect(Collectors.toList());
+        this.isPublic = custom.getIsPublic();
+        this.isOwner = isOwner;
+    }
 
     public CustomListItemDto(Object[] result) {
         Bookmark bookmark = result[1] instanceof Bookmark ? ((Bookmark) result[1]) : null;
         Practice practice = result[2] instanceof Practice ? ((Practice) result[2]) : null;
         this.practiced = practice != null;
         this.bookmarked = bookmark != null;
-        this.recommended = false;
 
         this.date = practiced ? practice.getModifiedDate() : null;
 
@@ -38,5 +56,6 @@ public class CustomListItemDto {
                 .map(customCtag -> customCtag.getTag().getName())
                 .collect(Collectors.toList());
         this.isPublic = custom.getIsPublic();
+        this.isOwner = false;
     }
 }

--- a/src/main/java/yeonjeans/saera/exception/ErrorCode.java
+++ b/src/main/java/yeonjeans/saera/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     /*400 BAD_REQUEST*/
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 누락된 값이 없는 지 확인해주세요."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. image파일만 업로드 가능합니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, "잘못된 타입의 요청입니다. 학습타입을 확인해주세요."),
     EXCEED_FILE_SIZE(HttpStatus.BAD_REQUEST, "5MB이하의 이미지 파일만 업로드할 수 있습니다."),
     PUBLIC_CANT_DEL(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 공개된 사용자 정의 문장은 삭제할 수 없습니다."),
 


### PR DESCRIPTION
### /practice-word 분리
- 단어억양학습 진행 시 ML서버로 부터 결과 return되게 수정
- /practice api -> STATMENT, CUSTOM 타입만 학습 진행
- 맞지 않는 TYPE의 학습 요청 시, 400err + msg 응답 추가

### /customs 수정
- dto 클래스 통일
- isOWner 필드 추가하여 구분되도록 구현.